### PR TITLE
Add Max Retries to Elasticsearch Client Settings (Closes #103)

### DIFF
--- a/core/src/main/scala/com.snowplowanalytics.stream/loader/model.scala
+++ b/core/src/main/scala/com.snowplowanalytics.stream/loader/model.scala
@@ -74,6 +74,7 @@ package model {
     username: Option[String],
     password: Option[String],
     maxTimeout: Long,
+    maxRetries: Int,
     ssl: Boolean
   )
   case class ESAWSConfig(signing: Boolean, region: String)

--- a/elasticsearch/src/main/scala/com/snowplowanalytics/stream/loader/ElasticsearchStreamLoaderApp.scala
+++ b/elasticsearch/src/main/scala/com/snowplowanalytics/stream/loader/ElasticsearchStreamLoaderApp.scala
@@ -46,7 +46,8 @@ object ElasticsearchStreamLoaderApp extends StreamLoaderApp {
         esConfig.client.password,
         esConfig.client.maxTimeout,
         CredentialsLookup.getCredentialsProvider(config.aws.accessKey, config.aws.secretKey),
-        tracker
+        tracker,
+        esConfig.client.maxRetries
       )
   }
 

--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -133,6 +133,7 @@ elasticsearch {
     username = "{{elasticsearchUsername}}"
     password = "{{elasticsearchPassword}}"
     maxTimeout = "{{elasticsearchMaxTimeout}}"
+    maxRetries = {{elasticsearchMaxRetries}}
     ssl = {{sslBool}}
   }
 


### PR DESCRIPTION
It is a nice-to-have flexible option for busy Elasticsearch clusters.

CC: @nafid @zakipatel