### PR TITLE
Sharded indices by date (closes #82)

### DIFF
--- a/core/src/main/scala/com.snowplowanalytics.stream/loader/JsonRecord.scala
+++ b/core/src/main/scala/com.snowplowanalytics.stream/loader/JsonRecord.scala
@@ -24,5 +24,6 @@ import org.json4s.JValue
  * Format in which Snowplow events are buffered
  *
  * @param json The JSON string for the event
+ * @param shard optional shard to send the data
  */
-case class JsonRecord(json: JValue)
+case class JsonRecord(json: JValue, shard: Option[String])

--- a/core/src/main/scala/com.snowplowanalytics.stream/loader/KinesisPipeline.scala
+++ b/core/src/main/scala/com.snowplowanalytics.stream/loader/KinesisPipeline.scala
@@ -47,6 +47,8 @@ class KinesisPipeline(
   goodSink: Option[ISink],
   badSink: ISink,
   bulkSender: BulkSender[EmitterJsonInput],
+  shardDateField: Option[String],
+  shardDateFormat: Option[String],
   bufferRecordLimit: Long,
   bufferByteLimit: Long,
   tracker: Option[Tracker] = None
@@ -60,7 +62,7 @@ class KinesisPipeline(
     new BasicMemoryBuffer[ValidatedJsonRecord](configuration)
 
   override def getTransformer(c: KinesisConnectorConfiguration) = streamType match {
-    case Good      => new EnrichedEventJsonTransformer
+    case Good      => new EnrichedEventJsonTransformer(shardDateField, shardDateFormat)
     case PlainJson => new PlainJsonTransformer
     case Bad       => new BadEventTransformer
 

--- a/core/src/main/scala/com.snowplowanalytics.stream/loader/executors/NsqSourceExecutor.scala
+++ b/core/src/main/scala/com.snowplowanalytics.stream/loader/executors/NsqSourceExecutor.scala
@@ -60,6 +60,8 @@ class NsqSourceExecutor(
   config: StreamLoaderConfig,
   goodSink: Option[ISink],
   badSink: ISink,
+  shardDateField: Option[String],
+  shardDateFormat: Option[String],
   bulkSender: BulkSender[EmitterJsonInput]
 ) extends Runnable {
 
@@ -75,7 +77,7 @@ class NsqSourceExecutor(
     config.streams.buffer.recordLimit,
     config.streams.buffer.byteLimit)
   private val transformer = streamType match {
-    case Good      => new EnrichedEventJsonTransformer
+    case Good      => new EnrichedEventJsonTransformer(shardDateField, shardDateFormat)
     case PlainJson => new PlainJsonTransformer
     case Bad       => new BadEventTransformer
   }

--- a/core/src/main/scala/com.snowplowanalytics.stream/loader/model.scala
+++ b/core/src/main/scala/com.snowplowanalytics.stream/loader/model.scala
@@ -74,6 +74,8 @@ package model {
     port: Int,
     username: Option[String],
     password: Option[String],
+    shardDateFormat: Option[String],
+    shardDateField: Option[String],
     maxTimeout: Long,
     maxRetries: Int,
     ssl: Boolean

--- a/core/src/main/scala/com.snowplowanalytics.stream/loader/transformers/BadEventTransformer.scala
+++ b/core/src/main/scala/com.snowplowanalytics.stream/loader/transformers/BadEventTransformer.scala
@@ -52,7 +52,7 @@ class BadEventTransformer
    */
   override def toClass(record: Record): ValidatedJsonRecord = {
     val recordString = new String(record.getData.array, UTF_8)
-    (recordString, JsonRecord(JObject(JField("source", JString(recordString)))).success)
+    (recordString, JsonRecord(JObject(JField("source", JString(recordString))), None).success)
   }
 
   /**
@@ -62,5 +62,5 @@ class BadEventTransformer
    * @return Line as an EmitterJsonInput
    */
   def consumeLine(line: String): EmitterJsonInput =
-    fromClass(line -> JsonRecord(JObject(JField("source", JString(line)))).success)
+    fromClass(line -> JsonRecord(JObject(JField("source", JString(line))), None).success)
 }

--- a/core/src/main/scala/com.snowplowanalytics.stream/loader/transformers/PlainJsonTransformer.scala
+++ b/core/src/main/scala/com.snowplowanalytics.stream/loader/transformers/PlainJsonTransformer.scala
@@ -64,7 +64,7 @@ class PlainJsonTransformer
   private def toJsonRecord(jsonString: String): ValidationNel[String, JsonRecord] = {
     parseOpt(jsonString) match {
       case Some(jvalue) =>
-        JsonRecord(jvalue ++ ("id" -> UUID.randomUUID().toString)).success
+        JsonRecord(jvalue ++ ("id" -> UUID.randomUUID().toString), None).success
       case None => "Json parsing error".failureNel
     }
   }

--- a/core/src/test/scala/com.snowplowanalytics.stream.loader/BadEventTransformerSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.stream.loader/BadEventTransformerSpec.scala
@@ -37,7 +37,8 @@ class BadEventTransformerSpec extends Specification {
     "successfully convert a bad event JSON to an ElasticsearchObject" in {
       val input =
         """{"line":"failed","errors":["Record does not match Thrift SnowplowRawEvent schema"]}"""
-      val result = new BadEventTransformer().fromClass(input -> JsonRecord(parse(input)).success)
+      val result =
+        new BadEventTransformer().fromClass(input -> JsonRecord(parse(input), None).success)
       val json: String = compact(
         render(result._2.getOrElse(throw new RuntimeException("Json failed transformation")).json))
       json.toString must_== input

--- a/core/src/test/scala/com.snowplowanalytics.stream.loader/EmitterSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.stream.loader/EmitterSpec.scala
@@ -79,7 +79,7 @@ class EmitterSpec extends Specification {
         new KinesisConnectorConfiguration(new Properties, new DefaultAWSCredentialsProviderChain)
       val eem = new Emitter(fakeSender, None, new StdouterrSink, 1, 1L)
 
-      val validInput: EmitterJsonInput   = "good" -> JsonRecord(parse("{}")).success
+      val validInput: EmitterJsonInput   = "good" -> JsonRecord(parse("{}"), None).success
       val invalidInput: EmitterJsonInput = "bad"  -> "malformed event".failureNel
 
       val input = List(validInput, invalidInput)
@@ -100,7 +100,7 @@ class EmitterSpec extends Specification {
       val ess = new MockElasticsearchSender
       val eem = new Emitter(ess, None, new StdouterrSink, 1, 1000L)
 
-      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}")).success
+      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}"), None).success
 
       val input = List.fill(50)(validInput)
 
@@ -124,7 +124,7 @@ class EmitterSpec extends Specification {
       val ess = new MockElasticsearchSender
       val eem = new Emitter(ess, None, new StdouterrSink, 1, 1000L)
 
-      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}")).success
+      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}"), None).success
 
       val input = List(validInput)
 
@@ -148,7 +148,7 @@ class EmitterSpec extends Specification {
       val ess = new MockElasticsearchSender
       val eem = new Emitter(ess, None, new StdouterrSink, 100, 1048576L)
 
-      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}")).success
+      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}"), None).success
 
       val input = List.fill(50)(validInput)
 
@@ -172,7 +172,7 @@ class EmitterSpec extends Specification {
       val ess = new MockElasticsearchSender
       val eem = new Emitter(ess, None, new StdouterrSink, 1, 1048576L)
 
-      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}")).success
+      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}"), None).success
 
       val input = List(validInput)
 
@@ -197,7 +197,7 @@ class EmitterSpec extends Specification {
       val eem = new Emitter(ess, None, new StdouterrSink, 2, 200L)
 
       // record size is 95 bytes
-      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}")).success
+      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("{}"), None).success
 
       val input = List.fill(20)(validInput)
 

--- a/core/src/test/scala/com.snowplowanalytics.stream.loader/PlainJsonTransformerSpec.scala
+++ b/core/src/test/scala/com.snowplowanalytics.stream.loader/PlainJsonTransformerSpec.scala
@@ -37,7 +37,8 @@ class PlainJsonTransformerSpec extends Specification {
     "successfully convert a  plain JSON to an JsonRecord" in {
       val input = """{"key1":"value1","key2":"value2","key3":"value3"}"""
 
-      val result = new PlainJsonTransformer().fromClass(input -> JsonRecord(parse(input)).success)
+      val result =
+        new PlainJsonTransformer().fromClass(input -> JsonRecord(parse(input), None).success)
       val json: String = compact(
         render(
           result._2.getOrElse(throw new RuntimeException("Plain Json failed transformation")).json))

--- a/elasticsearch/src/main/scala/com/snowplowanalytics/stream/loader/clients/ElasticsearchBulkSender.scala
+++ b/elasticsearch/src/main/scala/com/snowplowanalytics/stream/loader/clients/ElasticsearchBulkSender.scala
@@ -90,11 +90,15 @@ class ElasticsearchBulkSender(
     val (successes, oldFailures)   = records.partition(_._2.isSuccess)
     val successfulRecords = successes.collect {
       case (_, Success(r)) =>
+        val index = r.shard match {
+          case Some(shardSuffix) => documentIndex + shardSuffix
+          case None              => documentIndex
+        }
         utils.extractEventId(r.json) match {
           case Some(id) =>
-            new ElasticsearchObject(documentIndex, documentType, id, compact(render(r.json)))
+            new ElasticsearchObject(index, documentType, id, compact(render(r.json)))
           case None =>
-            new ElasticsearchObject(documentIndex, documentType, compact(render(r.json)))
+            new ElasticsearchObject(index, documentType, compact(render(r.json)))
         }
     }
     val actions =

--- a/elasticsearch/src/test/scala/com/snowplowanalytics/stream/loader/clients/ElasticsearchBulkSenderSpec.scala
+++ b/elasticsearch/src/test/scala/com/snowplowanalytics/stream/loader/clients/ElasticsearchBulkSenderSpec.scala
@@ -53,7 +53,7 @@ class ElasticsearchBulkSenderSpec extends Specification {
   "send" should {
     "successfully send stuff" in {
 
-      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("""{"s":"json"}""")).success
+      val validInput: EmitterJsonInput = "good" -> JsonRecord(parse("""{"s":"json"}"""), None).success
       val input                        = List(validInput)
 
       sender.send(input) must_== List.empty

--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -127,6 +127,8 @@ elasticsearch {
   #   - for transport this is usually 9300
   # - username (optional, remove if not active): http basic auth username
   # - password (optional, remove if not active): http basic auth password
+  # - shardDateFormat (optional, remove if not needed): formatting used for sharding good stream, i.e. _yyyy-MM-dd
+  # - shardDateField (optional, if not specified derived_tstamp is used): timestamp field for sharding good stream
   # - max-timeout: the maximum attempt time before a client restart
   # - ssl: if using the http client, whether to use ssl or not
   client {
@@ -134,6 +136,8 @@ elasticsearch {
     port = "{{elasticsearchTransportPort}}"
     username = "{{elasticsearchUsername}}"
     password = "{{elasticsearchPassword}}"
+    shardDateFormat = "{{elasticsearchShardDateFormat}}"
+    shardDateField = "{{elasticsearchShardDateField}}"
     maxTimeout = "{{elasticsearchMaxTimeout}}"
     maxRetries = {{elasticsearchMaxRetries}}
     ssl = {{sslBool}}


### PR DESCRIPTION
This PR provides an option to have Elasticsearch documents stored in different indices based on one of the available date fields. 
Sharding of the data can be disabled by ignoring these parameters, can be very coarse-grained like monthly shards or can be fine-grained i.e. daily for larger websites. It depends on the format field.

CC: @Nafid