### PR TITLE
Fix typo in logging output (closes #173)

### DIFF
--- a/elasticsearch/src/main/scala/com/snowplowanalytics/stream/loader/clients/ElasticsearchBulkSender.scala
+++ b/elasticsearch/src/main/scala/com/snowplowanalytics/stream/loader/clients/ElasticsearchBulkSender.scala
@@ -131,7 +131,7 @@ class ElasticsearchBulkSender(
       }
     } else Nil
 
-    log.info(s"Emitted ${esObjects.size - newFailures.size} records to Elasticseacrch")
+    log.info(s"Emitted ${esObjects.size - newFailures.size} records to Elasticsearch")
     if (newFailures.nonEmpty) logHealth()
 
     val allFailures = oldFailures ++ newFailures


### PR DESCRIPTION
Closes: https://github.com/snowplow/snowplow-elasticsearch-loader/issues/173

Change `Elasticseacrch` to `Elasticsearch`